### PR TITLE
Add a line between rules with the same entity

### DIFF
--- a/src/Text/Brick/Driver/LR1.hs
+++ b/src/Text/Brick/Driver/LR1.hs
@@ -150,10 +150,15 @@ find k m = maybe mempty id (Map.lookup k m)
 instance Show Grammar where
   show g =
     g.order
-      & map ruleShowTable
-      & untable
+      & groupEntities
+      & map (unlines . untable . map ruleShowTable)
       & unlines
     where
+      groupEntities =
+        map (map snd) .
+        groupBy ((==) `on` fst) .
+        map \r -> (r.entity, r)
+
       untable :: [[String]] -> [String]
       untable tbl = do
         let


### PR DESCRIPTION
```
0 . S = Module

1 . Module = "module" QCtor "where" Import+ Toplevel+
2 . Module = "module" QCtor "where" Toplevel+        
3 . Module = "module" QCtor "where" Import+          
4 . Module = "module" QCtor "where"                  

5 . Import+ = Import        
6 . Import+ = Import Import+

7 . Toplevel+ = Toplevel          
8 . Toplevel+ = Toplevel Toplevel+

9  . Import = "use" Ctor/Dot "as" Ctor/Dot "{" NameOrCtor/Separator "}"
10 . Import = "use" Ctor/Dot "as" Ctor/Dot                             
11 . Import = "use" Ctor/Dot "{" NameOrCtor/Separator "}"              
12 . Import = "use" Ctor/Dot                                           

13 . Ctor/Dot = Ctor             
14 . Ctor/Dot = Ctor Dot Ctor/Dot
...
```