### PR TITLE
Add cabal support to the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work
 *.prof
 *.cabal
+dist-newstyle

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages: ./*.cabal
+allow-newer: shower:base


### PR DESCRIPTION
Problem: you can't just use hpack and compile this project by cabal

Solution: add cabal.project, that will fix broken shower upperbound